### PR TITLE
Fix typos and correct link

### DIFF
--- a/app/components/SearchPanel/index.jsx
+++ b/app/components/SearchPanel/index.jsx
@@ -24,7 +24,7 @@ function Header(props) {
             })
             .catch((err) => {
                 // alert(JSON.stringify(err));
-                alert('Someting went wrong, Please try again later.');
+                alert('Something went wrong, Please try again later.');
             });
     }, []);
 

--- a/app/navigation/index.jsx
+++ b/app/navigation/index.jsx
@@ -59,7 +59,7 @@ function CustomDrawerContent(props) {
         },
         {
             label: 'Terms of Use',
-            onClick: () => Linking.openURL('https://mosafir.ma/terms-of-us'),
+            onClick: () => Linking.openURL('https://mosafir.ma/terms-of-use'),
             icon: require(`../assets/cpp.png`),
         },
         {

--- a/app/screens/TripDetails/index.jsx
+++ b/app/screens/TripDetails/index.jsx
@@ -56,7 +56,7 @@ function TripDetails({ navigation, route }) {
                 setTrips(trips);
             })
             .catch((err) => {
-                alert('Someting went wrong, Please try again later.');
+                alert('Something went wrong, Please try again later.');
             })
             .finally(() => {
                 setLoading(false);
@@ -155,7 +155,7 @@ function TripDetails({ navigation, route }) {
                                 textAlign: 'center',
                                 ...fontFamily['bold'],
                             }}>
-                            Opps..
+                            Oops..
                         </Text>
                         <Text
                             style={{


### PR DESCRIPTION
## Summary
- fix 'Something went wrong' alert text
- correct message when no trips are found
- update Terms of Use link

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f506b0c64833281ea263913bee4d7