### PR TITLE
Remove keystore details from gradle.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ local.properties
 *.hprof
 .cxx/
 *.keystore
+*.jks
 !debug.keystore
 
 # node.js

--- a/README.md
+++ b/README.md
@@ -5,14 +5,19 @@ This project is a React Native application.
 ## Android build instructions
 
 1. Install Android Studio and ensure the Android SDK is available.
-2. Create `android/local.properties` with the path to your SDK:
-3. Ensure the keystore passwords in `android/gradle.properties` are correct.
+2. Create `android/local.properties` with the path to your SDK and your release keystore settings or export them as environment variables. Example:
 
 ```
 sdk.dir=/path/to/Android/sdk
+MYAPP_UPLOAD_STORE_FILE=/path/to/keystore.jks
+MYAPP_UPLOAD_KEY_ALIAS=your_alias
+MYAPP_UPLOAD_STORE_PASSWORD=your_store_password
+MYAPP_UPLOAD_KEY_PASSWORD=your_key_password
 ```
 
-4. Run the build:
+`android/local.properties` is ignored by git, so it can safely contain these values.
+
+3. Run the build:
 
 ```bash
 npm install

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -17,11 +17,9 @@ hermesEnabled=true
 # Optional: enable new architecture if needed
 newArchEnabled=false
 
-# Keystore config for release signing (adjust if needed)
-MYAPP_UPLOAD_STORE_FILE=keystore.jks
-MYAPP_UPLOAD_KEY_ALIAS=upload
-MYAPP_UPLOAD_STORE_PASSWORD=123456789
-MYAPP_UPLOAD_KEY_PASSWORD=123456789
+# Keystore config for release signing
+# Define these properties in `android/local.properties` or as environment variables
+# (MYAPP_UPLOAD_STORE_FILE, MYAPP_UPLOAD_KEY_ALIAS, MYAPP_UPLOAD_STORE_PASSWORD, MYAPP_UPLOAD_KEY_PASSWORD)
 
 # Kotlin and Java setup
 kotlin.jvmTarget=17


### PR DESCRIPTION
## Summary
- clean gradle.properties of hardcoded keystore values
- document keystore setup in README
- ignore `.jks` files in gitignore

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f5063efe48332b8d032b45ff5a5b8